### PR TITLE
Fixes RRQ not waiting for ACK of last package

### DIFF
--- a/py3tftp/protocols.py
+++ b/py3tftp/protocols.py
@@ -281,11 +281,12 @@ class RRQProtocol(BaseTFTPProtocol):
         if (self.is_correct_tid(addr) and packet.is_ack() and
                 packet.is_correct_sequence(self.counter)):
             self.conn_timeout_reset()
+            if self.file_handler.finished:
+                self.transport.close()
+                return
             self.counter = (self.counter + 1) % 65536
             packet = self.next_datagram()
             self.reply_to_client(packet.to_bytes())
-            if self.file_handler.finished:
-                self.transport.close()
         else:
             logging.debug('Ack: {0}; is_ack: {1}; counter: {2}'.format(
                 data, packet.is_ack(), self.counter))


### PR DESCRIPTION
Duringn an RRQ, the server closes the connection
right after sending the last package. It does it before
receiving the client ACK for that package.

Previously, if the last package
was not received by the client (no ACK), it would not be resent.