### PR TITLE
handle error packets if client aborts RRQ transfer

### DIFF
--- a/py3tftp/protocols.py
+++ b/py3tftp/protocols.py
@@ -278,6 +278,9 @@ class RRQProtocol(BaseTFTPProtocol):
         to client.
         """
         packet = self.packet_factory.from_bytes(data)
+        if (self.is_correct_tid(addr) and packet.is_err()):
+            self.handle_err_pkt()
+            return
         if (self.is_correct_tid(addr) and packet.is_ack() and
                 packet.is_correct_sequence(self.counter)):
             self.conn_timeout_reset()


### PR DESCRIPTION
without this patch transfers would timeout and spam log
a PXE booting client may abort the transfer because the server does not handle the tsize option