### PR TITLE
Fix timeout interval handling

### DIFF
--- a/py3tftp/cli_parser.py
+++ b/py3tftp/cli_parser.py
@@ -36,12 +36,12 @@ def parse_cli_arguments():
               'requires superuser privileges.'))
     parser.add_argument(
         '--ack-timeout',
+        dest="timeout",
         default=0.5,
         type=float,
         help='Timeout for each ACK of the lock-step. Default: 0.5.')
     parser.add_argument(
         '--conn-timeout',
-        dest="timeout",
         default=3.0,
         type=float,
         help=('Timeout before the server gives up on a transfer and closes '

--- a/py3tftp/protocols.py
+++ b/py3tftp/protocols.py
@@ -18,7 +18,7 @@ class BaseTFTPProtocol(asyncio.DatagramProtocol):
         b'windowsize': tftp_parsing.windowsize_parser,
     }
 
-    default_opts = {b'ack_timeout': 0.5, b'timeout': 5.0, b'blksize': 512,
+    default_opts = {b'timeout': 0.5, b'conn_timeout': 5.0, b'blksize': 512,
                     b'windowsize': 1}
 
     def __init__(self, packet, file_handler_cls, remote_addr, extra_opts=None):
@@ -142,16 +142,16 @@ class BaseTFTPProtocol(asyncio.DatagramProtocol):
         """
         self.reply_to_client(packet)
         self.h_timeout = asyncio.get_event_loop().call_later(
-            self.opts[b'timeout'], self.conn_timeout)
+            self.opts[b'conn_timeout'], self.conn_timeout)
 
     def reply_to_client(self, packet):
         """
         Starts the message retry loop, resending packet to self.remote_addr
-        every 'ack_timeout'.
+        every 'timeout'.
         """
         self.transport.sendto(packet, self.remote_addr)
         self.retransmit = asyncio.get_event_loop().call_later(
-            self.opts[b'ack_timeout'], self.reply_to_client, packet)
+            self.opts[b'timeout'], self.reply_to_client, packet)
         if self.opts[b'windowsize'] > 1:
             self.retransmits.append(self.retransmit)
 
@@ -203,7 +203,7 @@ class BaseTFTPProtocol(asyncio.DatagramProtocol):
 
         self.conn_reset()
         self.h_timeout = asyncio.get_event_loop().call_later(
-            self.opts[b'timeout'], self.conn_timeout)
+            self.opts[b'conn_timeout'], self.conn_timeout)
 
     def is_correct_tid(self, addr):
         """


### PR DESCRIPTION
RFC2349 Timeout Interval Option should target the ACK timeout and not the connection timeout. Therefore renamed `ack_timeout` as `timeout`, and `timeout` as `conn_timeout`.

This fixes also the issue where the `--conn-timeout` gets overwritten with the RFC2349 mechanism. This is why I started to debug the issue and wondered why that argument had no effect (combined with a bad u-boot client with 5sec ACK timeout).