### PR TITLE
Server should respond over same socker UDP socket.

### DIFF
--- a/py3tftp/protocols.py
+++ b/py3tftp/protocols.py
@@ -406,8 +406,7 @@ class BaseTFTPServerProtocol(asyncio.DatagramProtocol):
 
         connect = self.loop.create_datagram_endpoint(
             lambda: protocol(data, file_handler_cls, addr, self.extra_opts),
-            local_addr=(self.host_interface,
-                        0, ))
+            sock=self.transport.get_extra_info('socket'))
 
         self.loop.create_task(connect)
 

--- a/tests/unit/protocols_test.py
+++ b/tests/unit/protocols_test.py
@@ -32,6 +32,7 @@ class TestTFTPServerProtocol(t.TestCase):
         mock_loop.create_task.return_value = True
 
         proto = TFTPServerProtocol('127.0.0.1', mock_loop, {})
+        proto.transport = MagicMock()
 
         proto.datagram_received(data, ('127.0.0.1', 0,))
         self.assertTrue(mock_loop.create_datagram_endpoint.called)


### PR DESCRIPTION
When running in docker (--net=bridge) on Ubuntu 22.04
we hit a problem where the TFTP responses were not
routed properly. After some investigation we concluded
that the response got lost because it was coming from a
different (random) host:port.

The patch in question re-uses the server socket for
the UDP response so that reverse NAT treversal is
possible in stricter network topologies.